### PR TITLE
Task/api 1161 edit coverage eligibility response transformer for DARs

### DIFF
--- a/urgent-care/pom.xml
+++ b/urgent-care/pom.xml
@@ -11,7 +11,7 @@
   <packaging>jar</packaging>
   <properties>
     <ee-artifacts.version>1.1.31</ee-artifacts.version>
-    <r4.version>1.0.2</r4.version>
+    <r4.version>1.0.3</r4.version>
   </properties>
   <dependencies>
     <dependency>

--- a/urgent-care/pom.xml
+++ b/urgent-care/pom.xml
@@ -11,7 +11,7 @@
   <packaging>jar</packaging>
   <properties>
     <ee-artifacts.version>1.1.31</ee-artifacts.version>
-    <r4.version>1.0.1</r4.version>
+    <r4.version>1.0.2</r4.version>
   </properties>
   <dependencies>
     <dependency>

--- a/urgent-care/src/main/java/gov/va/api/health/urgentcare/service/api/UrgentCareService.java
+++ b/urgent-care/src/main/java/gov/va/api/health/urgentcare/service/api/UrgentCareService.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.urgentcare.service.api;
 
-import gov.va.api.health.r4.api.CoverageApi;
 import gov.va.api.health.r4.api.CoverageEligibilityResponseApi;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
@@ -31,8 +30,7 @@ import javax.ws.rs.Path;
       )
 )
 @Path("/")
-public interface UrgentCareService
-    extends CoverageApi, CoverageEligibilityResponseApi, MetadataApi {
+public interface UrgentCareService extends CoverageEligibilityResponseApi, MetadataApi {
   class UrgentCareServiceException extends RuntimeException {
     UrgentCareServiceException(String message) {
       super(message);

--- a/urgent-care/src/main/java/gov/va/api/health/urgentcare/service/controller/coverageeligibilityresponse/CoverageEligibilityResponseTransformer.java
+++ b/urgent-care/src/main/java/gov/va/api/health/urgentcare/service/controller/coverageeligibilityresponse/CoverageEligibilityResponseTransformer.java
@@ -71,6 +71,7 @@ public class CoverageEligibilityResponseTransformer implements Transformer {
     return CoverageEligibilityResponse.builder()
         .resourceType("CoverageEligibilityResponse")
         .text(text())
+        .id(source.getIcn())
         .identifier(identifier())
         .status(Status.active)
         .purpose(singletonList(Purpose.discovery))

--- a/urgent-care/src/main/java/gov/va/api/health/urgentcare/service/controller/coverageeligibilityresponse/CoverageEligibilityResponseTransformer.java
+++ b/urgent-care/src/main/java/gov/va/api/health/urgentcare/service/controller/coverageeligibilityresponse/CoverageEligibilityResponseTransformer.java
@@ -6,6 +6,7 @@ import static gov.va.api.health.urgentcare.service.controller.Transformers.conve
 import static gov.va.api.health.urgentcare.service.controller.Transformers.ifPresent;
 import static java.util.Collections.singletonList;
 
+import gov.va.api.health.r4.api.DataAbsentReason;
 import gov.va.api.health.r4.api.datatypes.CodeableConcept;
 import gov.va.api.health.r4.api.datatypes.Coding;
 import gov.va.api.health.r4.api.datatypes.Identifier;
@@ -61,16 +62,6 @@ public class CoverageEligibilityResponseTransformer implements Transformer {
         Coding.builder().code(source.getVceCode()).display(source.getVceDescription()).build());
   }
 
-  Reference coverage() {
-    return Reference.builder()
-        .identifier(
-            Identifier.builder()
-                .system("http://www.va.gov/identifiers/patients")
-                .id("PatientPlaceholder")
-                .build())
-        .build();
-  }
-
   private CoverageEligibilityResponse coverageEligibilityResponse(
       GetEeSummaryResponseTheRemix source) {
     return CoverageEligibilityResponse.builder()
@@ -81,7 +72,8 @@ public class CoverageEligibilityResponseTransformer implements Transformer {
         .purpose(singletonList(Purpose.discovery))
         .patient(Reference.builder().display("Patient/" + source.getIcn()).build())
         .created(asDateTimeString(source.getEeSummaryResponse().getInvocationDate()) + ".000-06:00")
-        .request(Reference.builder().display("Requested by [placeholder]").build())
+        .request(null)
+        ._request(DataAbsentReason.of(DataAbsentReason.Reason.unsupported))
         .outcome(Outcome.complete)
         .insurer(Reference.builder().display("Veterans Health Administration").build())
         .insurance(insurances(source.getEeSummaryResponse().getSummary()))
@@ -111,7 +103,8 @@ public class CoverageEligibilityResponseTransformer implements Transformer {
         ifPresent(eligibilities, VceEligibilityCollection::getEligibility),
         eligibilityInfo ->
             Insurance.builder()
-                .coverage(coverage())
+                .coverage(null)
+                ._coverage(DataAbsentReason.of(DataAbsentReason.Reason.unsupported))
                 .benefitPeriod(benefitPeriod(eligibilityInfo.getVceEffectiveDate()))
                 .item(item(eligibilityInfo))
                 .build());

--- a/urgent-care/src/main/resources/application.properties
+++ b/urgent-care/src/main/resources/application.properties
@@ -3,6 +3,7 @@ urgent-care.url=unset
 urgent-care.base-path=api
 queenelizabeth.url=unset
 health-check.id=unset
+identityservice.url=unset
 
 security.require-ssl=true
 server.ssl.key-store-type=JKS

--- a/urgent-care/src/test/java/gov/va/api/health/urgentcare/service/controller/coverageeligibilityresponse/CoverageEligibilityTransformerTest.java
+++ b/urgent-care/src/test/java/gov/va/api/health/urgentcare/service/controller/coverageeligibilityresponse/CoverageEligibilityTransformerTest.java
@@ -4,6 +4,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import gov.va.api.health.r4.api.DataAbsentReason;
 import gov.va.api.health.r4.api.datatypes.CodeableConcept;
 import gov.va.api.health.r4.api.datatypes.Coding;
 import gov.va.api.health.r4.api.datatypes.Identifier;
@@ -145,16 +146,6 @@ public class CoverageEligibilityTransformerTest {
       return singletonList(Coding.builder().code("B").display("basic").build());
     }
 
-    Reference coverage() {
-      return Reference.builder()
-          .identifier(
-              Identifier.builder()
-                  .system("http://www.va.gov/identifiers/patients")
-                  .id("PatientPlaceholder")
-                  .build())
-          .build();
-    }
-
     CoverageEligibilityResponse coverageEligibilityResponse() {
       return CoverageEligibilityResponse.builder()
           .resourceType("CoverageEligibilityResponse")
@@ -164,7 +155,8 @@ public class CoverageEligibilityTransformerTest {
           .purpose(asList(Purpose.discovery))
           .patient(patient())
           .created("2018-11-07T00:00:00.000-06:00")
-          .request(request())
+          .request(null)
+          ._request(DataAbsentReason.of(DataAbsentReason.Reason.unsupported))
           .outcome(Outcome.complete)
           .insurer(insurer())
           .insurance(insurances())
@@ -180,7 +172,8 @@ public class CoverageEligibilityTransformerTest {
 
     Insurance insurance() {
       return Insurance.builder()
-          .coverage(coverage())
+          .coverage(null)
+          ._coverage(DataAbsentReason.of(DataAbsentReason.Reason.unsupported))
           .benefitPeriod(Period.builder().start("2018-11-07T00:00:00").build())
           .item(items())
           .build();

--- a/urgent-care/src/test/java/gov/va/api/health/urgentcare/service/controller/coverageeligibilityresponse/CoverageEligibilityTransformerTest.java
+++ b/urgent-care/src/test/java/gov/va/api/health/urgentcare/service/controller/coverageeligibilityresponse/CoverageEligibilityTransformerTest.java
@@ -150,6 +150,7 @@ public class CoverageEligibilityTransformerTest {
       return CoverageEligibilityResponse.builder()
           .resourceType("CoverageEligibilityResponse")
           .text(text())
+          .id("123456789")
           .identifier(asList(identifier()))
           .status(Status.active)
           .purpose(asList(Purpose.discovery))


### PR DESCRIPTION
It has been decided to DAR required fields request and coverage in the CoverageEligibilityResponse resource as we do not support the reference types. Update transformer to return DARs in both fields, add tests.
Related story: https://vasdvp.atlassian.net/browse/API-1161