### PR TITLE
Update health-apis-urgent-care-eligibility to handle Integer total within Bundle.

### DIFF
--- a/urgent-care/pom.xml
+++ b/urgent-care/pom.xml
@@ -11,7 +11,7 @@
   <version>2.0.16-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <r4.version>2.0.14-SNAPSHOT</r4.version>
+    <r4.version>2.0.14</r4.version>
     <ee-apis-parent.version>3.0.2</ee-apis-parent.version>
     <swagger-maven-plugin.version>2.0.8</swagger-maven-plugin.version>
   </properties>

--- a/urgent-care/pom.xml
+++ b/urgent-care/pom.xml
@@ -11,7 +11,7 @@
   <version>2.0.17-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <r4.version>2.0.14</r4.version>
+    <r4.version>2.0.15</r4.version>
     <ee-apis-parent.version>3.0.2</ee-apis-parent.version>
     <swagger-maven-plugin.version>2.0.8</swagger-maven-plugin.version>
   </properties>

--- a/urgent-care/pom.xml
+++ b/urgent-care/pom.xml
@@ -11,7 +11,7 @@
   <version>2.0.16-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <r4.version>2.0.11</r4.version>
+    <r4.version>2.0.14-SNAPSHOT</r4.version>
     <ee-apis-parent.version>3.0.2</ee-apis-parent.version>
     <swagger-maven-plugin.version>2.0.8</swagger-maven-plugin.version>
   </properties>

--- a/urgent-care/src/main/java/gov/va/api/health/urgentcare/service/controller/Bundler.java
+++ b/urgent-care/src/main/java/gov/va/api/health/urgentcare/service/controller/Bundler.java
@@ -32,7 +32,7 @@ public class Bundler {
     B bundle = context.newBundle().get();
     bundle.resourceType("Bundle");
     bundle.type(BundleType.searchset);
-    bundle.total("1");
+    bundle.total(1);
     bundle.link(links.create(context.linkConfig()));
     bundle.entry(
         context

--- a/urgent-care/src/test/java/gov/va/api/health/urgentcare/service/api/swaggerexamples/SwaggerCoverageEligibilityResponse.java
+++ b/urgent-care/src/test/java/gov/va/api/health/urgentcare/service/api/swaggerexamples/SwaggerCoverageEligibilityResponse.java
@@ -70,7 +70,7 @@ public class SwaggerCoverageEligibilityResponse {
       Bundle.builder()
           .resourceType("Bundle")
           .type(BundleType.searchset)
-          .total(String.valueOf(1))
+          .total(1)
           .link(
               asList(
                   BundleLink.builder()

--- a/urgent-care/src/test/java/gov/va/api/health/urgentcare/service/controller/BundlerTest.java
+++ b/urgent-care/src/test/java/gov/va/api/health/urgentcare/service/controller/BundlerTest.java
@@ -55,7 +55,7 @@ public class BundlerTest {
     FugaziBundle expected = new FugaziBundle();
     expected.resourceType("Bundle");
     expected.type(BundleType.searchset);
-    expected.total("1");
+    expected.total(1);
     expected.link(bundleLinks);
     expected.entry(
         Arrays.asList(


### PR DESCRIPTION
To determine ripple effects of the change of AbstractBundle, total from String to Integer (which appear negligible), I went ahead and just updated UCE.
Note that this is blocked by https://github.com/department-of-veterans-affairs/health-apis-fhir-resources/pull/30.  (I put the snapshot version in the pom to build locally.)